### PR TITLE
Update accessibility statement

### DIFF
--- a/app/templates/content/accessibility-statement.html
+++ b/app/templates/content/accessibility-statement.html
@@ -26,11 +26,11 @@
         Accessibility statement
       </h1>
 
-      <p class="govuk-body">Last updated: 22 September 2020</p>
+      <p class="govuk-body">Last updated: 10 September 2021</p>
 
       <h2 class="govuk-heading-m">Introduction</h2>
-      <p class="govuk-body">This statement applies to content published on the www.digitalmarketplace.service.gov.uk domain. It does not apply to content on GOV.UK (for example, www.gov.uk/guidance/g-cloud-suppliers-guide).</p>
-      <p class="govuk-body">This website is run by the Government Digital Service. It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:</p>
+      <p class="govuk-body">This statement applies to content published on the www.digitalmarketplace.service.gov.uk domain.</p>
+      <p class="govuk-body">This website is run by Crown Commercial Service. It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>change colours, contrast levels and fonts</li>
         <li>zoom in up to 300% without problems</li>
@@ -62,23 +62,21 @@
       <p class="govuk-body">The Equality and Human Rights Commission (<abbr title="Equality and Human Rights Commission">EHRC</abbr>) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the <a href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (<abbr title="Equality Advisory and Support Service">EASS</abbr>)</a>.</p>
 
       <h2 class="govuk-heading-m">Technical information about this website’s accessibility</h2>
-      <p class="govuk-body"><abbr title="Government Digital Service">GDS</abbr> is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</a></p>
       <p class="govuk-body">This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/" rel="external">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed below.</p>
 
       <h2 class="govuk-heading-m">Non accessible content</h2>
-      <p class="govuk-body">The content listed below is non-accessible for the following reasons:</p>
-      
-      <h3 class="govuk-heading-s">Non compliance with the accessibility regulations</h3>
-      <p class="govuk-body">Some pages don’t clearly identify content within the page. This fails <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 A success criterion 2.4.2 (title of a Web page not identifying the contents).</p>
-      <p class="govuk-body">Not all our interactive elements meet the required non-text contrast ratio. This fails WCAG 2.1 AA success criterion 1.4.11  (non-text contrast).</p>
-      <p class="govuk-body">Labeled elements on some pages are not declared by screen readers. This fails WCAG 2.1 A success criterion 2.5.3 (label in name).</p>
-      <p class="govuk-body">Not all our journeys offer consistent navigation. This fails WCAG 2.1 AA success criterion 3.2.3 (consistent navigation).</p>
-      <p class="govuk-body">Some error messages include irrelevant text and do not direct screen reader users to an error message link. This fails WCAG 2.1 A success criterion 3.3.1 (error identification).</p>
-      <p class="govuk-body">Search and sitemap functionality is missing. This fails WCAG 2.1 AA success criterion 2.4.5 (multiple ways).</p>
-      <p class="govuk-body">Screen readers do not declare the state or function of some elements correctly. This fails WCAG 2.1 A  success criterion 4.1.2 (name,role,value).</p>
-
+      <p class="govuk-body">The following content does not comply with the accessibility regulations:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>some pages don’t clearly identify content within the page. This fails <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 A success criterion 2.4.2 (title of a Web page not identifying the contents).</li>
+        <li>not all our interactive elements meet the required non-text contrast ratio. This fails WCAG 2.1 AA success criterion 1.4.11  (non-text contrast).</li>
+        <li>labeled elements on some pages are not declared by screen readers. This fails WCAG 2.1 A success criterion 2.5.3 (label in name).</li>
+        <li>not all our journeys offer consistent navigation. This fails WCAG 2.1 AA success criterion 3.2.3 (consistent navigation).</li>
+        <li>some error messages include irrelevant text and do not direct screen reader users to an error message link. This fails WCAG 2.1 A success criterion 3.3.1 (error identification).</li>
+        <li>search and sitemap functionality is missing. This fails WCAG 2.1 AA success criterion 2.4.5 (multiple ways).</li>
+        <li>screen readers do not declare the state or function of some elements correctly. This fails WCAG 2.1 A  success criterion 4.1.2 (name,role,value).</li>
+      </ul>
       <h3 class="govuk-heading-s">Disproportionate burden</h3>
-      <p class="govuk-body">We will not seek to offer accessible PDFs due to the technical complexity of making the changes and anticipated migration of the platform.</p>
+      <p class="govuk-body">Crown Commercial Service will not seek full WCAG compliance due to the anticipated retirement of the platform.</p>
 
       <h2 class="govuk-heading-m">Content not within the scope of the accessibility regulations</h2>
       <h3 class="govuk-heading-s">PDFs and other documents</h3>
@@ -86,10 +84,8 @@
 
       <h2 class="govuk-heading-m">How we tested this website</h2>
       <p class="govuk-body">This website was tested for compliance with the Web Content Accessibility Guidelines V2.1 level A and level AA. Tests have been carried out externally and internally.</p>
-
-      <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
-      <p class="govuk-body">We plan to fix all known issues by September 2021.</p>
-      <p class="govuk-body">This statement was prepared on 22 September 2020. It was last updated on 22 September 2020.</p>
+      
+      <p class="govuk-body">This statement was prepared on 22 September 2020. It was last updated on 10 September 2021.</p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
CCS have taken the decision not to do any further accessibility work on the DMP. This means we will not continue upgrading the components, simplifying the content or the journeys. It also means we will no longer fix any further audit findings or enforce suppliers to provide accessible documents for G-Cloud 13.

CCS have agreed to  accept any risk involved with WCAG non-compliance.

The document with the new accessibility statement is here (non-public) - https://docs.google.com/document/d/1J8XTAmVhggb37JOBN6mQAHfHjcL2GUey8N5_hrjw-E4/edit#heading=h.oatxqcvcmg79

https://trello.com/c/e7CC9df9/105-update-the-accessibility-statement