### PR TITLE
OST-571 - Make G-Cloud projects visible, even if all frameworks expired

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -32,6 +32,24 @@ def get_latest_live_framework_or_404(all_frameworks, framework_family):
     return latest_live_framework
 
 
+def get_last_live_framework_or_404(all_frameworks, framework_family):
+    frameworks_in_family = list((f for f in all_frameworks if f['framework'] == framework_family))
+
+    if not frameworks_in_family:
+        abort(404, f"No frameworks found for `{framework_family}` family")
+
+    try:
+        return max(
+            (f for f in frameworks_in_family if f['status'] == 'live'),
+            key=lambda f: f['id'],
+        )
+    except ValueError:  # max of empty iterable
+        return max(
+            (f for f in frameworks_in_family),
+            key=lambda f: f['id'],
+        )
+
+
 def get_lots_by_slug(framework_data):
     return {lot['slug']: lot for lot in framework_data['lots']}
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -421,10 +421,7 @@ def saved_search_overview(framework_family):
     }
 
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
-
-    content_loader.load_messages(framework['slug'], ['descriptions', 'urls'])
-    framework_short_description = content_loader.get_message(framework['slug'], 'descriptions', 'framework_short')
+    framework_helpers.get_last_live_framework_or_404(all_frameworks, framework_family)
 
     projects = get_direct_award_projects(data_api_client, current_user.id, latest_first=True)
     projects['closed_projects'].sort(key=itemgetter('lockedAt'), reverse=True)
@@ -482,8 +479,6 @@ def saved_search_overview(framework_family):
         'direct-award/index.html',
         open_projects=open_projects,
         closed_projects=closed_projects,
-        framework=framework,
-        framework_short_description=framework_short_description
     )
 
 
@@ -827,7 +822,10 @@ def update_project(framework_family, project_id):
 )
 def did_you_award_contract(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
+    framework = framework_helpers.get_last_live_framework_or_404(
+        all_frameworks,
+        framework_family
+    )
 
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -894,8 +892,10 @@ def which_service_won_contract(framework_family, project_id):
         abort(410)
 
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework_or_404(
-        all_frameworks, framework_family)
+    framework = framework_helpers.get_last_live_framework_or_404(
+        all_frameworks,
+        framework_family
+    )
 
     search = data_api_client.find_direct_award_project_searches(user_id=current_user.id,
                                                                 project_id=project['id'],
@@ -945,7 +945,10 @@ def which_service_won_contract(framework_family, project_id):
 )
 def tell_us_about_contract(framework_family, project_id, outcome_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
+    framework = framework_helpers.get_last_live_framework_or_404(
+        all_frameworks,
+        framework_family
+    )
 
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -1001,8 +1004,10 @@ def tell_us_about_contract(framework_family, project_id, outcome_id):
 )
 def why_did_you_not_award_the_contract(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework_or_404(
-        all_frameworks, framework_family)
+    framework = framework_helpers.get_last_live_framework_or_404(
+        all_frameworks,
+        framework_family
+    )
 
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,6 +64,31 @@ def get_frameworks_list_fixture_data():
     return {'frameworks': [framework['frameworks'] for framework in frameworks]}
 
 
+def get_expired_frameworks_list_fixture_data():
+    frameworks = [
+        FrameworkStub(
+            id=4, slug='g-cloud-7', status='expired', lots=as_a_service_lots()
+        ).single_result_response(),
+        FrameworkStub(
+            id=1, slug='g-cloud-6', status='expired', lots=as_a_service_lots()
+        ).single_result_response(),
+        FrameworkStub(
+            id=6, slug='g-cloud-8', status='expired', lots=as_a_service_lots(),
+        ).single_result_response(),
+        FrameworkStub(
+            id=3, slug='g-cloud-5', status='expired', lots=as_a_service_lots()
+        ).single_result_response(),
+        FrameworkStub(
+            id=2, slug='g-cloud-4', status='expired', lots=as_a_service_lots()
+        ).single_result_response(),
+        FrameworkStub(
+            id=8, slug='g-cloud-9', status='expired', lots=cloud_lots()
+        ).single_result_response(),
+    ]
+
+    return {'frameworks': [framework['frameworks'] for framework in frameworks]}
+
+
 class BaseAPIClientMixin:
     """
     Mixin for patching the API clients when imported for each view module.
@@ -221,6 +246,10 @@ class BaseApplicationTest(object):
     @staticmethod
     def _get_frameworks_list_fixture_data():
         return get_frameworks_list_fixture_data()
+
+    @staticmethod
+    def _get_expired_frameworks_list_fixture_data():
+        return get_expired_frameworks_list_fixture_data()
 
     @staticmethod
     def _get_g4_service_fixture_data():


### PR DESCRIPTION
Ticket: [OST-571](https://crowncommercialservice.atlassian.net/browse/OST-571)

Even though G-Cloud 12 is expired, we still want the page to view projects to be accessible to the user.

I have created a helper which will get the latest framework (including if it is not live) or raise a 404 to replace some of calls to a method that would return a 404 if there were no live frameworks.

I’ve also added some tests to make sure my changes have worked (all previous tests should have worked without the need to make any changes)