### PR TITLE
OST-570 - Remove link to search on dashboard

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -206,17 +206,19 @@
         </li>
         {% endif %}
 
-        <li>
-          <strong>
-            <a class="govuk-link"
-               href="{{ url_for('main.index_g_cloud') }}">
-              Find {{ gcloud_framework_description }}
-            </a>
-          </strong>
-          <p class="govuk-body">
-            eg content delivery networks or accounting software
-          </p>
-        </li>
+        {% if gcloud_framework_description %}
+          <li>
+            <strong>
+              <a class="govuk-link"
+                href="{{ url_for('main.index_g_cloud') }}">
+                Find {{ gcloud_framework_description }}
+              </a>
+            </strong>
+            <p class="govuk-body">
+              eg content delivery networks or accounting software
+            </p>
+          </li>
+        {% endif %}
 
         <li>
           <strong>

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -183,6 +183,26 @@ class TestHomepageBrowseList(APIClientMixin, BaseApplicationTest):
         assert link_texts[1] == "Find physical datacentre space"
         assert len(link_texts) == 2
 
+    def test_g_cloud_links_are_not_shown_if_no_live_g_cloud_frameworks(self):
+        mock_expired_g_cloud_9_framework = self.mock_live_g_cloud_9_framework.copy()
+        mock_expired_g_cloud_9_framework.update({"status": "expired"})
+
+        self.data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                mock_expired_g_cloud_9_framework,
+            ]
+        }
+
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+
+        link_texts = [item.text_content().strip() for item in document.cssselect('#app-buyer-nav a')]
+        assert len(link_texts) == 1
+        assert "Find cloud hosting, software and support" not in link_texts
+        assert "Find physical datacentre space" in link_texts
+
 
 class TestHomepageSidebarMessage(APIClientMixin, BaseApplicationTest):
 


### PR DESCRIPTION
Ticket: [OST-570](https://crowncommercialservice.atlassian.net/browse/OST-570)

Remove link to search on dashboard so that it will not appear once there are no live frameworks