### PR TITLE
OST-572 - Make sure the search is accessible while g-cloud-12 is still live

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -271,6 +271,13 @@ class BaseApplicationTest(object):
         }
 
     @staticmethod
+    def _get_expired_framework_fixture_data(framework_slug):
+        return {
+            'frameworks': next(f for f in BaseApplicationTest._get_expired_frameworks_list_fixture_data()['frameworks']
+                               if f['slug'] == framework_slug)
+        }
+
+    @staticmethod
     def _get_dos_brief_fixture_data(multi=False):
         if multi:
             return BaseApplicationTest._get_fixture_data('dos_multiple_briefs_fixture.json')

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1,4 +1,10 @@
 # coding: utf-8
+import mock
+
+from lxml import html
+
+from dmapiclient import APIError
+
 from ...helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
@@ -10,13 +16,215 @@ class TestSuppliersPage(DataAPIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
+        self.suppliers_by_prefix = self._get_suppliers_by_prefix_fixture_data()
+        self.suppliers_by_prefix_page_2 = self._get_suppliers_by_prefix_fixture_data_page_2()
+        self.suppliers_by_prefix_next_and_prev = self._get_suppliers_by_prefix_fixture_with_next_and_prev()
         self.supplier = self._get_supplier_fixture_data()
         self.supplier_with_minimum_data = self._get_supplier_with_minimum_fixture_data()
+        self.data_api_client.find_suppliers.return_value = self.suppliers_by_prefix
         self.data_api_client.get_supplier.return_value = self.supplier
 
-    def test_should_redirect_to_apply_to_supply(self):
+        gcloud9_framework = self._get_framework_fixture_data('g-cloud-9')['frameworks']
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [gcloud9_framework]}
+
+    def test_should_call_api_with_correct_params(self):
+        self.client.get('/g-cloud/suppliers')
+        self.data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
+
+    def test_should_show_suppliers_prefixed_by_a_default(self):
+        res = self.client.get('/g-cloud/suppliers')
+        assert res.status_code == 200
+        assert self._strip_whitespace(
+            '<li class="selected"><span class="govuk-visually-hidden">'
+            'Suppliers starting with </span><strong>A</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_show_suppliers_prefixed_by_a_param(self):
+        res = self.client.get('/g-cloud/suppliers?prefix=M')
+        self.data_api_client.find_suppliers.assert_called_once_with('M', 1, 'g-cloud')
+        assert res.status_code == 200
+        assert self._strip_whitespace(
+            '<li class="selected"><span class="govuk-visually-hidden">'
+            'Suppliers starting with </span><strong>M</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_use_uppercase_prefix(self):
+        res = self.client.get('/g-cloud/suppliers?prefix=b')
+        assert res.status_code == 200
+        assert self._strip_whitespace(
+            '<li class="selected"><span class="govuk-visually-hidden">'
+            'Suppliers starting with </span><strong>B</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_use_default_if_invalid(self):
+        res = self.client.get('/g-cloud/suppliers?prefix=+')
+        self.data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
+
+        assert res.status_code == 200
+        assert self._strip_whitespace(
+            '<li class="selected"><span class="govuk-visually-hidden">'
+            'Suppliers starting with </span><strong>A</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_use_default_if_multichar_prefix(self):
+        res = self.client.get('/g-cloud/suppliers?prefix=Prefix')
+        self.data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
+
+        assert res.status_code == 200
+
+        assert self._strip_whitespace(
+            '<li class="selected"><span class="govuk-visually-hidden">'
+            'Suppliers starting with </span><strong>A</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_use_number_range_prefix(self):
+        res = self.client.get('/g-cloud/suppliers?prefix=other')
+        self.data_api_client.find_suppliers.assert_called_once_with(u'other', 1, 'g-cloud')
+
+        assert res.status_code == 200
+        assert self._strip_whitespace(
+            u'<li class="selected"><span class="govuk-visually-hidden">Suppliers starting with </span>' +
+            u'<strong>1–9</strong></li>'
+        ) in self._strip_whitespace(res.get_data(as_text=True))
+
+    def test_should_show_supplier_names_link_and_description(self):
+        res = self.client.get('/g-cloud/suppliers')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath(
+            "//*[contains(@class, 'search-result')]"
+            "[.//h2//a[@href=$u][normalize-space(string())=$t]]"
+            "[.//p[normalize-space(string())=$b]]",
+            u="/g-cloud/supplier/586559",
+            t="ABM UNITED KINGDOM LTD",
+            b="""We specialise in the development of intelligence and investigative software across law enforcement agencies, public sector and commercial organisations. We provide solutions to clients across the globe, including the United Kingdom, Australia, USA, Canada and Europe.""",  # noqa
+        )
+
+    def test_should_show_a_t_z_nav(self):
+        res = self.client.get('/g-cloud/suppliers')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        nav_lis = document.xpath(
+            "//li[.//*[contains(@class, 'govuk-visually-hidden')][normalize-space(string())=$s]][.//a[@href]]",
+            s="Suppliers starting with",
+        )
+        expected_strings = (
+            ("Suppliers starting with B", "B", "/g-cloud/suppliers?prefix=B",),
+            ("Suppliers starting with C", "C", "/g-cloud/suppliers?prefix=C",),
+            ("Suppliers starting with D", "D", "/g-cloud/suppliers?prefix=D",),
+            ("Suppliers starting with E", "E", "/g-cloud/suppliers?prefix=E",),
+            ("Suppliers starting with F", "F", "/g-cloud/suppliers?prefix=F",),
+            ("Suppliers starting with G", "G", "/g-cloud/suppliers?prefix=G",),
+            ("Suppliers starting with H", "H", "/g-cloud/suppliers?prefix=H",),
+            ("Suppliers starting with I", "I", "/g-cloud/suppliers?prefix=I",),
+            ("Suppliers starting with J", "J", "/g-cloud/suppliers?prefix=J",),
+            ("Suppliers starting with K", "K", "/g-cloud/suppliers?prefix=K",),
+            ("Suppliers starting with L", "L", "/g-cloud/suppliers?prefix=L",),
+            ("Suppliers starting with M", "M", "/g-cloud/suppliers?prefix=M",),
+            ("Suppliers starting with N", "N", "/g-cloud/suppliers?prefix=N",),
+            ("Suppliers starting with O", "O", "/g-cloud/suppliers?prefix=O",),
+            ("Suppliers starting with P", "P", "/g-cloud/suppliers?prefix=P",),
+            ("Suppliers starting with Q", "Q", "/g-cloud/suppliers?prefix=Q",),
+            ("Suppliers starting with R", "R", "/g-cloud/suppliers?prefix=R",),
+            ("Suppliers starting with S", "S", "/g-cloud/suppliers?prefix=S",),
+            ("Suppliers starting with T", "T", "/g-cloud/suppliers?prefix=T",),
+            ("Suppliers starting with U", "U", "/g-cloud/suppliers?prefix=U",),
+            ("Suppliers starting with V", "V", "/g-cloud/suppliers?prefix=V",),
+            ("Suppliers starting with W", "W", "/g-cloud/suppliers?prefix=W",),
+            ("Suppliers starting with X", "X", "/g-cloud/suppliers?prefix=X",),
+            ("Suppliers starting with Y", "Y", "/g-cloud/suppliers?prefix=Y",),
+            ("Suppliers starting with Z", "Z", "/g-cloud/suppliers?prefix=Z",),
+            ("Suppliers starting with 1–9", "1–9", "/g-cloud/suppliers?prefix=other",),
+        )
+
+        assert tuple(
+            (
+                nl.xpath("normalize-space(string())"),
+                nl.xpath("normalize-space(string(.//a))"),
+                nl.xpath(".//a/@href")[0],
+            ) for nl in nav_lis
+        ) == expected_strings
+        # these lis should all have the same parent
+        assert len(frozenset(nl.getparent() for nl in nav_lis)) == 1
+        # that parent should only have one other li
+        assert len(nav_lis[0].getparent().getchildren()) == len(expected_strings) + 1
+        # that li should be the first and match this pattern
+        assert nav_lis[0].getparent().xpath(
+            "./*[1][normalize-space(string())=$t][not(.//a[@href])]",
+            t="Suppliers starting with A",
+        )
+
+    def test_should_show_no_suppliers_page_if_api_returns_404(self):
+        self.data_api_client.find_suppliers.side_effect = APIError(mock.Mock(status_code=404))
+
+        res = self.client.get('/g-cloud/suppliers')
+        assert res.status_code == 404
+
+    def test_should_show_next_page_on_supplier_list(self):
+        res = self.client.get('/g-cloud/suppliers')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath("//li[contains(@class, 'next')]")
+        assert document.xpath(
+            "//a[starts-with(@href, $u)][contains(@href, $px)][contains(@href, $pg)]",
+            u="/g-cloud/suppliers?",
+            px="prefix=A",
+            pg="page=2",
+        )
+
+    def test_should_show_next_nav_on_supplier_list(self):
+        self.data_api_client.find_suppliers.return_value = self.suppliers_by_prefix_page_2  # noqa
+        res = self.client.get('/g-cloud/suppliers?page=2')
+        self.data_api_client.find_suppliers.assert_called_once_with('A', 2, 'g-cloud')
+
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath("//li[contains(@class, 'previous')]")
+        assert document.xpath(
+            "//a[starts-with(@href, $u)][contains(@href, $px)][contains(@href, $pg)]",
+            u="/g-cloud/suppliers?",
+            px="prefix=A",
+            pg="page=1",
+        )
+
+    def test_should_show_next_and_prev_nav_on_supplier_list(self):
+        self.data_api_client.find_suppliers.return_value = self.suppliers_by_prefix_next_and_prev  # noqa
+        res = self.client.get('/g-cloud/suppliers?page=2')
+
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath("//li[contains(@class, 'previous')]")
+        assert document.xpath(
+            "//a[starts-with(@href, $u)][contains(@href, $px)][contains(@href, $pg)]",
+            u="/g-cloud/suppliers?",
+            px="prefix=A",
+            pg="page=1",
+        )
+
+        assert document.xpath("//li[contains(@class, 'next')]")
+        assert document.xpath(
+            "//a[starts-with(@href, $u)][contains(@href, $px)][contains(@href, $pg)]",
+            u="/g-cloud/suppliers?",
+            px="prefix=A",
+            pg="page=3",
+        )
+
+    def test_should_redirect_to_apply_to_supply_when_no_live_frameworks(self):
+        gcloud9_framework = self._get_expired_framework_fixture_data('g-cloud-9')['frameworks']
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [gcloud9_framework]}
+
         response = self.client.get('/g-cloud/suppliers')
-        assert 301 == response.status_code
+        assert 302 == response.status_code
         assert "https://www.applytosupply.digitalmarketplace.service.gov.uk/g-cloud/suppliers" == response.location
 
     def test_should_have_supplier_details_on_supplier_page(self):


### PR DESCRIPTION
Ticket: [OST-572](https://crowncommercialservice.atlassian.net/browse/OST-572)

I realised I made a mistake as the list should still be accessible (even for a few days) before G-Cloud 12 is expired