### PR TITLE
OST-578 - Remove search links and the ability to export results

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -672,10 +672,15 @@ def view_project(framework_family, project_id):
         search_summary_sentence = search_meta.search_summary.markup()
         can_end_search = _can_end_search(search_meta)
         framework = frameworks_by_slug[search_meta.framework_slug]
+        latest_live_framework = framework_helpers.get_latest_live_framework(frameworks_by_slug.values(), 'g-cloud')
+        if not latest_live_framework:
+            can_end_search = True
+
         buyer_search_page_url = search_meta.url
 
     else:
         framework = framework_helpers.get_latest_live_framework(frameworks_by_slug.values(), 'g-cloud')
+        latest_live_framework = framework
 
         search = None
         buyer_search_page_url = None
@@ -723,6 +728,7 @@ def view_project(framework_family, project_id):
     return render_template(
         'direct-award/view-project.html',
         framework=framework,
+        latest_live_framework=latest_live_framework,
         following_framework=following_framework,
         project=project,
         custom_dimensions=custom_dimensions,

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -120,25 +120,23 @@
           <p class="app-search-summary app-search-summary--small govuk-body-s">{{ search_summary_sentence }}</p>
 
           {% if not search.searchedAt %}
-
-          {% if "save-a-search" in errors %}
-          <div class="govuk-form-group--error">
-            <span class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span>
-              {{ errors["save-a-search"].text }}
-            </span>
-          {% endif %}
-
-            <p class="govuk-body">
-              <a class="govuk-link" href="{{ buyer_search_page_url }}">
-                Edit your search and view results
-              </a>
-            </p>
-
-          {% if "too_many_results" in errors %}
-          </div>
-          {% endif %}
-
+            {% if latest_live_framework %}
+              {% if "save-a-search" in errors %}
+              <div class="govuk-form-group--error">
+                <span class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span>
+                  {{ errors["save-a-search"].text }}
+                </span>
+              {% endif %}
+                <p class="govuk-body">
+                  <a class="govuk-link" href="{{ buyer_search_page_url }}">
+                    Edit your search and view results
+                  </a>
+                </p>
+              {% if "too_many_results" in errors %}
+              </div>
+              {% endif %}
+            {% endif %}
           {% endif %}
           {% if search.searchedAt or can_end_search %}
             {{ govukTag({
@@ -157,11 +155,23 @@
           Export your results
         </h2>
 
-        <p class="govuk-body">
-          Export a list of the services you’ve found. Download suppliers’ service
-          descriptions and contact details to help you assess services. Keep a copy
-          for your records.
-        </p>
+        {% if not search.searchedAt and can_end_search and not latest_live_framework %}
+          <p class="govuk-body">
+            You cannot export these results as the framework you used to create them, {{ framework['name'] }}, has expired. You can start a new search for G-Cloud 13 by going to the
+            <a class="govuk-link"
+              href="https://www.contractawardservice.crowncommercial.gov.uk/projects/create-or-choose"
+              data-analytics="trackEvent"
+              data-analytics-category="CAS"
+              data-analytics-action="External Link"
+            >Contract Award Service</a>.
+          </p>
+        {% else %}
+          <p class="govuk-body">
+            Export a list of the services you’ve found. Download suppliers’ service
+            descriptions and contact details to help you assess services. Keep a copy
+            for your records.
+          </p>
+        {% endif %}
 
         {% if project %}
           {% if not (search.searchedAt or can_end_search) %}
@@ -170,18 +180,20 @@
               "text": "Cannot start yet"
             }) }}
           {% elif not search.searchedAt and can_end_search %}
-            {{ govukButton({
-              "href": url_for("direct_award.end_search", framework_family=framework.family, project_id=project.id),
-              "text": "Export your results",
+            {% if latest_live_framework %}
+              {{ govukButton({
+                "href": url_for("direct_award.end_search", framework_family=framework.family, project_id=project.id),
+                "text": "Export your results",
 
-              "classes": "govuk-!-margin-bottom-1",
+                "classes": "govuk-!-margin-bottom-1",
 
-              "attributes": {
-                "data-analytics": "trackEvent",
-                "data-analytics-category": "Direct Award",
-                "data-analytics-action": "Internal Link",
-              }
-            }) }}
+                "attributes": {
+                  "data-analytics": "trackEvent",
+                  "data-analytics-category": "Direct Award",
+                  "data-analytics-action": "Internal Link",
+                }
+              }) }}
+            {% endif %}
           {% elif project and search.searchedAt %}
             <p class="govuk-body">
               <a class="govuk-link"


### PR DESCRIPTION
Ticket: [OST-578](https://crowncommercialservice.atlassian.net/browse/OST-578)

Now that G-Cloud 12 has expired, we need to block buyers from getting to the search or exporting their results which is what I have done in this commit. There is guidance to direct users to CAS if they have a saved search that they have not yet exported.